### PR TITLE
Update ipwatchd.c to low the poll interval to 100ms -- this saves earth resource.

### DIFF
--- a/doc/doxygen.conf
+++ b/doc/doxygen.conf
@@ -38,7 +38,7 @@ PROJECT_NAME           = IPwatchD
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 1.3.0
+PROJECT_NUMBER         = 1.4.0
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/src/ipwatchd.c
+++ b/src/ipwatchd.c
@@ -195,7 +195,7 @@ int main (int argc, char *argv[])
 	}
 
 	/* Initialize libpcap and listen on all interfaces */
-	h_pcap = pcap_open_live ("any", BUFSIZ, 0, 0, errbuf);
+	h_pcap = pcap_open_live ("any", BUFSIZ, 0, 100, errbuf);
 	if (h_pcap == NULL)
 	{
 		ipwd_message (IPWD_MSG_TYPE_ERROR, "Unable to create packet capture object - %s", errbuf);

--- a/src/ipwatchd.h
+++ b/src/ipwatchd.h
@@ -45,7 +45,7 @@
 
 
 //! String with IPwatchD version information
-#define IPWATCHD_VERSION "IPwatchD 1.3.0"
+#define IPWATCHD_VERSION "IPwatchD 1.4.0"
 
 //! Absolute path to pid file
 #define IPWD_PIDFILE "/var/run/ipwatchd.pid"


### PR DESCRIPTION
The timeout argument (by zero) is kinda expensive for normal ip conflict detection which makes high cpu load on all of debian OS. Low to 100ms.